### PR TITLE
 #2912 added fastp to list of packages

### DIFF
--- a/packages/bcbio-vc.yaml
+++ b/packages/bcbio-vc.yaml
@@ -14,6 +14,7 @@ bio_nextgen:
 - delly
 - duphold
 - extract-sv-reads
+- fastp
 - fastqc=0.11.7=5
 - fgbio
 - freebayes=1.1.0.46


### PR DESCRIPTION
`fastp` was missing in the list of packages. It is used in UMI processing, though.