### PR TITLE
OPS-2635 Install script now requires python3

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -9,14 +9,14 @@ ARG git_revision=master
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl wget git unzip tar gzip bzip2 xz-utils pigz ttf-dejavu && \
 # Support inclusion in Arvados pipelines
-    apt-get install -y --no-install-recommends libcurl4-gnutls-dev mbuffer python2.7-dev python-virtualenv && \
+    apt-get install -y --no-install-recommends libcurl4-gnutls-dev mbuffer python3 python3-venv && \
 # Not added by default to save space
 #   apt-get install -y libglu1-mesa && \
 # bcbio-nextgen installation
     mkdir -p /tmp/bcbio-nextgen-install && cd /tmp/bcbio-nextgen-install && \
     wget --no-check-certificate \
       https://raw.github.com/chapmanb/bcbio-nextgen/master/scripts/bcbio_nextgen_install.py && \
-    python bcbio_nextgen_install.py /usr/local/share/bcbio-nextgen \
+    python3 bcbio_nextgen_install.py /usr/local/share/bcbio-nextgen \
       --isolate --minimize-disk --nodata -u development --revision "$git_revision" && \
 #    /usr/local/share/bcbio-nextgen/anaconda/bin/conda install -y nomkl && \
     /usr/local/share/bcbio-nextgen/anaconda/bin/bcbio_nextgen.py upgrade -u development --revision "$git_revision" && \


### PR DESCRIPTION
`bcbio_nextgen_install.py` now requires python3.